### PR TITLE
Feature: Add zones input variable to optional sync a subset of zones in the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Provide a token to use, if you set `add_pr_comment` to "Yes".
 
 Default `"Not set"`.
 
+### `zones`
+
+Space separated list of zones to sync, leave empty to sync all zones in the config file.
+
+Default: `""` (empty string)
+
 ## Outputs
 
 ### plan

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
     description: 'Run octodns-sync in force mode?'
     required: false
     default: 'No'
+  zones:
+    description: 'Space separated list of zones to sync, leave empty to sync
+                  all zones in the config file'
+    required: false
+    default: ''
   pr_comment_token:
     description: 'Provide a token to use, if you set add_pr_comment to Yes.'
     required: true
@@ -42,6 +47,7 @@ runs:
         CONFIG_PATH: ${{ inputs.config_path }}
         DOIT: ${{ inputs.doit }}
         FORCE: ${{ inputs.force }}
+        ZONES: ${{ inputs.zones }}
       run: ${{ github.action_path }}/scripts/run.sh
       shell: bash
       working-directory: ${{ github.workspace }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- ([#104](https://github.com/solvaholic/octodns-sync/pull/104)) Add input **zones** to allow syncing a subset of configured zones.
+
 ## [3.0.1] - 2023-02-12
 
 ### Added

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,6 +10,8 @@
 _config_path=$CONFIG_PATH
 _doit=$DOIT
 _force=$FORCE
+_zones=$ZONES
+
 
 # Run octodns-sync.
 _logfile="${GITHUB_WORKSPACE}/octodns-sync.log"
@@ -31,7 +33,7 @@ else
   _force=
 fi
 
-if ! octodns-sync --config-file="${_config_path}" ${_doit} ${_force} \
+if ! octodns-sync --config-file="${_config_path}" ${_doit} ${_force} ${_zones} \
 1>"${_planfile}" 2>"${_logfile}"; then
   echo "FAIL: octodns-sync exited with an error."
   echo "FAIL: Here are the contents of ${_logfile}:"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD026 -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR will add the a zones input to utilize the "zone" parameter from octodns-sync to only sync specific zones from the configuration.

## Motivation and Context
We use the octodns-sync action to dry-run the zone changes in a PR.
But in most PR's only 1 or 2 zones are changed to it's a bit wasteful in api-calls and time to dry-run all the zones and not only the changed zones.
The octodns-sync application has support for this but the github action did not yet. 

## How Has This Been Tested?
This has been tested by creating a fork, and switching our real-world (staging and production) repo's over to the fork.
In combination with the `tj-actions/changed-files` github action, our PR's only dry-run altered zone yaml files.

Snippet from our GithubAction
```
on:
  pull_request:
    paths:
      - '/zones/*'

jobs:
  octodns-dryrun:
      ..........     
      - name: Get all changed zone files
        id: changed-zone-files
        uses: tj-actions/changed-files@v45
        with:
          files: |
            zones/**.yaml
      - name: List all changed zone files
        id: create-zones
        if: steps.changed-zone-files.outputs.any_changed == 'true'
        env:
          ALL_CHANGED_FILES: ${{ steps.changed-zone-files.outputs.all_changed_files }}
        run: |
          for file in ${ALL_CHANGED_FILES}; do
            zone=$(basename "$file" .yaml)
            zones="${zones} ${zone}."
          done
          echo ZONES=${zones} >> $GITHUB_OUTPUT
      - uses: maikelpoot/octodns-sync@zones
        id: generate-plan
        with:
          config_path: ./config.yaml
          force: 'Yes'
          zones: "${{ steps.create-zones.outputs.ZONES }}"
        env:
          ** Secrets **
      ..........
```

## Anything else?
Output of real PR (domain and target are redacted):
```
INFO  Manager __init__: config_file=./config.yaml, (octoDNS 1.3.0)
INFO  Manager _config_executor: max_workers=1
INFO  Manager _config_include_meta: include_meta=False
INFO  Manager _config_auto_arpa: auto_arpa=False
INFO  Manager __init__: global_processors=[]
INFO  Manager __init__: global_post_processors=[]
INFO  Manager __init__: provider=yamlgitops (octodns.provider.yaml 1.3.0)
INFO  Manager __init__: provider=redacted (octodns_redacted 0.0.0)
INFO  Manager __init__: plan_output=html (octodns.provider.plan 1.3.0)
INFO  Manager sync: eligible_zones=['example.com.'], eligible_targets=[], dry_run=True, force=True, plan_output_fh=<stdout>
INFO  Manager sync:   zone=example.com.
INFO  Manager sync:   sources=['yamlgitops']
INFO  Manager sync:   targets=['redacted']
INFO  YamlProvider[yamlgitops] populate:   found 20 records, exists=False
INFO  RedactedProvider[redacted] plan: desired=example.com.
INFO  RedactedProvider[redacted] populate:   found 13 records
INFO  RedactedProvider[redacted] plan:   Creates=7, Updates=1, Deletes=0, Existing Records=13
```

This sync only took 4 seconds to run, before (with all zones) a sync would take about 2.5 minutes (159 seconds).
