### PR TITLE
workaround to run inside containerized workflows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
         DOIT: ${{ inputs.doit }}
         FORCE: ${{ inputs.force }}
         ZONES: ${{ inputs.zones }}
-      run: ${{ github.action_path }}/scripts/run.sh
+      run: ${GITHUB_ACTION_PATH}/scripts/run.sh
       shell: bash
       working-directory: ${{ github.workspace }}
     - name: Add pull request comment
@@ -57,7 +57,7 @@ runs:
         ADD_PR_COMMENT: ${{ inputs.add_pr_comment }}
         PR_COMMENT_TOKEN: ${{ inputs.pr_comment_token }}
         COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
-      run: ${{ github.action_path }}/scripts/comment.sh
+      run: ${GITHUB_ACTION_PATH}/scripts/comment.sh
       shell: bash
       working-directory: ${{ github.workspace }}
 branding:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.1]
+
+### Fixed
+
+- ([#107](https://github.com/solvaholic/octodns-sync/pull/107)) `github.action_path` contains wrong path when used inside a container. ([actions/runner#2185](https://github.com/actions/runner/issues/2185))
+
+## [3.1.0]
 
 ### Added
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD026 -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
there is a long open [bug][1] preventing github.action_path from functioning correctly inside containerized runs on self-hosted runners. using this environment variable, documented [here][2], is equivalent and provides the correct path in both github-hosted and self-hosted runners using both bare or containerized workflows.

[1]: https://github.com/actions/runner/issues/2185
[2]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables

## Motivation and Context
without this, this action fails to run on self-hosted runners when a conainer image has been selected for the running workflow

## How Has This Been Tested?
tested on our own self-hosted runners as well as public runners. 