### PR TITLE
Research: How octodns-sync is used and where it fits in the octodns ecosystem

### DIFF
--- a/docs/research/octodns-design.md
+++ b/docs/research/octodns-design.md
@@ -1,0 +1,229 @@
+# octodns Design and Ecosystem
+
+Research into octodns/octodns's design, CLI tools, intended workflows, reference implementations, and ecosystem -- to inform what octodns-sync should (and shouldn't) automate. April 2026.
+
+## Design Philosophy
+
+From the docs and codebase:
+
+1. **DNS as code** -- DNS config lives in a repo, deployed like other infrastructure code
+2. **Pluggable architecture** -- providers, sources, processors are all swappable modules
+3. **Plan then apply** -- dry-run first (`octodns-sync`), then apply (`octodns-sync --doit`)
+4. **Safety by default** -- unsafe plans (too many changes) require `--force`; new checksum mode adds another gate
+5. **Multiple plan output formats** -- `PlanLogger` (default), `PlanJson`, `PlanMarkdown`, `PlanHtml`
+6. **Provider-agnostic** -- 40+ DNS providers supported via separate modules
+
+### The GitHub workflow octodns envisions
+
+From the [getting-started docs](https://octodns.readthedocs.io/en/latest/getting-started.html), the intended workflow is modeled after GitHub's own deployment process:
+
+1. **Create a PR** with DNS changes
+2. **Noop deploy** -- `octodns-sync` runs without `--doit` to show planned changes
+3. **Human review** -- teammate reviews the plan output + the config diff
+4. **Branch deploy** -- deploy from the PR branch (with ability to roll back to main)
+5. **Verify** -- check with `dig` and/or `octodns-report`
+6. **Merge** -- merge the PR after successful deployment
+
+This is a branch-deploy workflow, not a merge-then-deploy workflow. That's a key design distinction -- most octodns-sync users do merge-then-deploy instead.
+
+---
+
+## CLI Tools
+
+octodns provides **7 CLI commands**:
+
+| Command | Purpose | Automatable with Actions? |
+|---------|---------|--------------------------|
+| `octodns-sync` | Plan and/or apply DNS changes | **Yes** -- this is what octodns-sync does |
+| `octodns-validate` | Validate config and zone files (no provider calls) | **Yes** -- fast, safe, no secrets needed |
+| `octodns-dump` | Export current DNS state from a provider to YAML files | **Maybe** -- useful for initial setup or drift detection |
+| `octodns-report` | Query live DNS and report on records | **Maybe** -- useful for post-deploy verification |
+| `octodns-compare` | Compare records between two sources | **Maybe** -- useful for drift detection between providers |
+| `octodns-schema` | Generate JSON Schema for zone YAML files | **No** -- one-time dev tool |
+| `octodns-versions` | Print installed provider versions | **No** -- debugging tool |
+
+### CLI flags octodns-sync supports vs. what the Action exposes
+
+| CLI flag | Purpose | In Action? |
+|----------|---------|-----------|
+| `--config-file` | Config file path | Yes (`config_path`) |
+| `--doit` | Apply changes | Yes (`doit`) |
+| `--force` | Allow unsafe plans | Yes (`force`) |
+| `--checksum` | Verify plan checksum before applying | **No** |
+| `zone` (positional) | Limit to specific zone(s) | Yes (`zones`) |
+| `--source` | Limit to zones with specific source(s) | **No** |
+| `--target` | Limit to specific target(s) | **No** |
+| `--log-stream-stdout` | Send logs to stdout | **No** (implicit in how run.sh captures output) |
+| `--debug` | Verbose logging | **No** |
+| `--quiet` | Suppress non-essential output | **No** |
+
+### Plan output formats
+
+octodns natively supports structured plan output via the `manager.plan_outputs` config:
+
+| Format | Class | Good for |
+|--------|-------|----------|
+| Logger (default) | `PlanLogger` | Human-readable console output |
+| JSON | `PlanJson` | Machine-readable, programmatic consumption |
+| Markdown | `PlanMarkdown` | PR comments, documentation |
+| HTML | `PlanHtml` | Web dashboards, email reports |
+
+**Key insight**: octodns already has `PlanMarkdown` built in. The Action could configure `plan_outputs` to include `PlanMarkdown` and use that directly for PR comments instead of capturing raw stderr/stdout.
+
+---
+
+## Reference Implementations
+
+### hackclub/dns (206 stars)
+
+Listed in octodns docs as a sample implementation. 5 workflows:
+
+| Workflow | Trigger | What it does |
+|----------|---------|-------------|
+| `deploy.yml` | push to main, workflow_dispatch | `octodns-sync --doit` with force-label check |
+| `test.yml` | push, pull_request_target, merge_group | `octodns-sync` dry-run with read-only tokens |
+| `validate.yml` | push, pull_request_target, merge_group | YAML validation + sort-order check |
+| `stale.yml` | schedule | Close stale issues/PRs |
+| `contact-check.yml` | schedule | Check domain contacts |
+
+Notable patterns:
+- Uses `pull_request_target` with read-only API tokens (addresses [#72](https://github.com/solvaholic/octodns-sync/issues/72))
+- `--force` is controlled via a PR label, not a workflow input
+- Uses `concurrency` to prevent parallel deploys
+- Calls `octodns-sync` directly, does NOT use solvaholic/octodns-sync Action
+- Custom `bin/sort-zones` script for zone file ordering
+
+### kubernetes/k8s.io (Kubernetes project)
+
+Listed in octodns docs as a sample implementation. Uses a custom shell script approach:
+
+- Runs octodns-sync per-zone with `--debug` and `--log-stream-stdout`
+- Manages canary zones (canary.k8s.io.) alongside production zones
+- Pre-processes zone configs by merging multi-file zones
+- Uses Docker-based octodns, not pip install
+- Does NOT use GitHub Actions at all -- uses Prow CI
+
+Notable patterns:
+- Canary zone pattern: deploy to canary.{zone} first, verify, then deploy to {zone}
+- Per-zone invocation with explicit zone names
+- Log capture per zone for debugging
+
+### jekyll/dns (14 stars)
+
+Listed in octodns docs. Uses octodns-sync directly, simple push-to-deploy.
+
+---
+
+## What Workflows Make Sense to Automate?
+
+### Tier 1: Core (what octodns-sync already does)
+
+| Workflow | CLI | Trigger | Notes |
+|----------|-----|---------|-------|
+| **Plan** (dry-run) | `octodns-sync` | pull_request | Show what would change |
+| **Apply** (deploy) | `octodns-sync --doit` | push to main | Make the changes |
+| **Force apply** | `octodns-sync --doit --force` | manual/labeled | Override safety thresholds |
+
+### Tier 2: Valuable additions
+
+| Workflow | CLI | Trigger | Notes |
+|----------|-----|---------|-------|
+| **Validate** | `octodns-validate` | pull_request | Fast config validation, no secrets needed. Could be a separate Action or a mode of octodns-sync. |
+| **Checksum-gated apply** | `octodns-sync --doit --checksum=X` | push to main | Plan produces a checksum; apply only proceeds if checksum matches. Prevents TOCTOU bugs where config changes between plan and apply. **New octodns feature that no Action supports yet.** |
+
+### Tier 3: Useful but niche
+
+| Workflow | CLI | Trigger | Notes |
+|----------|-----|---------|-------|
+| **Dump** | `octodns-dump` | workflow_dispatch / schedule | Export current DNS state for initial setup or drift detection |
+| **Report** | `octodns-report` | push to main (post-deploy) | Verify deployed records match expectations |
+| **Compare** | `octodns-compare` | schedule | Detect drift between providers |
+
+---
+
+## Complementary Actions Worth Studying
+
+### Actions used in the octodns ecosystem
+
+| Action | Used by | Purpose |
+|--------|---------|---------|
+| `peter-evans/create-or-update-comment` | bsoyka, python-discord, felixdorn | Update PR comments (replaces add_pr_comment) |
+| `peter-evans/find-comment` | bsoyka, python-discord | Find existing comment to update |
+| `github/branch-deploy` | GrantBirki | IssueOps branch deployment |
+| `GrantBirki/json-yaml-validate` | hackclub | YAML validation on PRs |
+| `actions/github-script` | hackclub | Force-label detection from PR |
+
+### Design pattern references
+
+| Action | Why study it |
+|--------|-------------|
+| `hashicorp/setup-terraform` | Similar "infrastructure CLI wrapper" pattern; handles plan/apply separation well |
+| `bridgecrewio/checkov-action` | IaC validation action; similar to what octodns-validate would be |
+| `peter-evans/create-or-update-comment` | The de facto standard for PR comments in Actions |
+
+---
+
+## Gaps Between octodns Design and octodns-sync Action
+
+### Things octodns supports that the Action doesn't expose
+
+1. **`--source` and `--target` flags** -- antonydevanchi's fork added these
+2. **`--checksum` flag** -- new feature for safe plan-then-apply
+3. **`--debug` / `--quiet` flags** -- logging verbosity control
+4. **`octodns-validate`** -- config validation without provider credentials
+5. **Plan output formats** (`PlanMarkdown`, `PlanJson`, `PlanHtml`) -- the Action captures raw stdout/stderr; it could configure `plan_outputs` for structured output
+6. **Multiple config files** -- octodns supports `staging.yaml` + `production.yaml`; the Action only takes one `config_path`
+
+### Things the community does that the Action doesn't support well
+
+1. **Branch deploy workflow** -- octodns was designed for branch deploys, but most users do merge-then-deploy because the Action doesn't facilitate branch deploys
+2. **Update-in-place PR comments** -- most popular request, built outside the Action
+3. **`pull_request_target`** -- needed for fork PRs to access read-only secrets; [#72](https://github.com/solvaholic/octodns-sync/issues/72) is still open
+4. **Force via PR label** -- hackclub's elegant pattern; Action requires explicit input
+5. **Separate validate step** -- no secrets needed, fast, could run on every PR
+6. **Concurrency control** -- hackclub uses `concurrency:` to prevent parallel deploys; the Action's README doesn't mention this
+
+### Things the Action does that octodns doesn't need
+
+1. **Installing octodns** -- removed in v3.0.0, correctly delegated to user. But starburst997 fork tried to add it back in. There's still demand for a simpler setup.
+2. **Python setup** -- every single workflow does `setup-python` + `pip install` before the Action. This is friction.
+
+---
+
+## Recommendations
+
+### Align with octodns's design
+
+1. **Expose missing CLI flags**: `--source`, `--target`, `--debug`, `--checksum`
+2. **Leverage PlanMarkdown**: Configure `plan_outputs` to produce markdown natively instead of capturing raw output
+3. **Document the branch-deploy pattern**: This is how octodns was designed to be used
+
+### Consider a second Action: octodns-validate
+
+A lightweight Action that runs `octodns-validate` (no secrets required). Could run on every PR, including from forks. Fast validation feedback before the heavier sync step.
+
+### Consider the checksum workflow
+
+octodns's new `--checksum` flag enables a secure plan-then-apply pattern:
+1. PR: plan -> capture checksum
+2. Merge: apply with `--checksum=X` -> only proceeds if plan hasn't changed
+
+No Action supports this yet.
+
+### Study the setup friction
+
+Every user writes 3-5 steps before calling octodns-sync: checkout, setup-python, pip install requirements. The official Docker images (`octodns/octodns-docker`) solve this for Docker-based workflows. A composite action could optionally embed setup steps (like starburst997 tried).
+
+---
+
+## Ecosystem Overview
+
+| Repository | Stars | Role |
+|-----------|-------|------|
+| octodns/octodns | 3683 | Core tool |
+| hackclub/dns | 206 | Reference implementation |
+| octodns/octodns-cloudflare | 48 | Most-used provider |
+| sukiyaki/octodns-netbox | 40 | NetBox integration |
+| solvaholic/octodns-sync | 35 | This Action |
+| octodns/octodns-docker | 13 | Official Docker images |
+| jekyll/dns | 14 | Reference implementation |

--- a/docs/research/usage-and-roadmap.md
+++ b/docs/research/usage-and-roadmap.md
@@ -1,0 +1,328 @@
+# Usage Research and Roadmap Signals
+
+Research into how `solvaholic/octodns-sync` is used in the wild, and what the findings suggest for the project's direction. Based on public GitHub data collected April 2026.
+
+## Methodology
+
+- **19 forks** discovered via the GitHub API; 6 have changes ahead of upstream
+- **27 public workflow files** found via GitHub code search across 15 distinct repositories
+- **4 fork-based usages** found (GrantBirki and edkadigital use their own forks)
+- Only public repositories were analyzed; private usage is not represented
+- Findings are anonymous except where specific public work is credited
+
+---
+
+## Version Pinning
+
+| Version ref | Count | % |
+|-------------|-------|---|
+| `@main` (floating) | 14 | 54% |
+| `@v3.1.1` (exact) | 4 | 15% |
+| `@v3.0.1` (exact) | 3 | 12% |
+| `@v3` (major tag) | 2 | 8% |
+| `@SHA` (commit pin) | 2 | 8% |
+| `@issue92` (branch) | 1 | 4% |
+
+Over half of users pin to `@main`. Only 2 use the recommended `@v3` major tag pattern. This suggests either users don't know about version tags, or they want the latest fixes and accept the risk.
+
+**Signal**: Update README examples to use `@v3`. Fix the major-tag update workflow ([#108](https://github.com/solvaholic/octodns-sync/issues/108)) so `@v3` stays current.
+
+---
+
+## Input Usage
+
+### `config_path` (default: `public.yaml`)
+
+Nobody uses the default. Every single user sets a custom config path:
+
+| Config path | Count |
+|-------------|-------|
+| `production.yaml` | 4 |
+| `dns/config.yaml` | 4 |
+| Dynamic: `${{ needs.meta.outputs.config }}` | 4 |
+| `config/production.yaml` | 3 |
+| `config.yaml` | 3 |
+| `dns/dns.yaml` | 2 |
+| `octodns.yaml` | 2 |
+| `dns/production.yaml` | 2 |
+| `./config/production.yaml` | 1 |
+| `domains.yaml` | 1 |
+| `config/config.yaml` | 1 |
+
+**Signal**: Change the default to `config.yaml` (the most generic common choice), or remove the default entirely and make it required. Either change would better match real-world usage.
+
+### `doit` (default: `""`)
+
+| Value | Count |
+|-------|-------|
+| `--doit` | 16 |
+| (not set / default) | 9 |
+| Dynamic: `${{ steps.noop-check.outputs.doit }}` | 1 |
+| Empty string | 1 |
+
+Most deploy workflows set `--doit`. Plan/dry-run workflows omit it. One creative use dynamically computes it based on whether the deployment is a noop -- see [GrantBirki's branch-deploy workflow](https://github.com/GrantBirki/dns/blob/84071641c6e77db3f2bff91bd701600581f43bfe/.github/workflows/branch-deploy.yml).
+
+### `force` (default: `No`)
+
+| Value | Count |
+|-------|-------|
+| (not set / default) | 19 |
+| `Yes` | 6 |
+| Dynamic: `${{ steps.force-check.outputs.force }}` | 1 |
+| `True` | 1 |
+
+Force mode is used in ~25% of steps, typically in dry-run/plan workflows. One user passes `True` instead of `Yes`, which may not work as intended since the Action checks for `"Yes"` specifically.
+
+### `add_pr_comment` (default: `No`)
+
+| Value | Count |
+|-------|-------|
+| (not set / default) | 23 |
+| `Yes` | 4 |
+
+Only 15% of octodns-sync steps use the built-in PR comment feature. But 8 out of 27 workflows (30%) consume the `plan` output to build their own PR comments. Users prefer external comment actions (like `peter-evans/create-or-update-comment`) because they can update existing comments instead of adding new ones -- the exact pain point described in [#41](https://github.com/solvaholic/octodns-sync/issues/41).
+
+### `pr_comment_token` (default: `Not set`)
+
+| Pattern | Count |
+|---------|-------|
+| (not set) | 23 |
+| `${{ secrets.GITHUB_TOKEN }}` | 2 |
+| `${{ secrets.* }}` (other) | 2 |
+
+### `zones` (default: `""`)
+
+Zero public users use the `zones` input (added in v3.1.0). Either users don't need zone filtering, the feature isn't well-known, or the use case is limited to private repos.
+
+**Signal**: Don't deprecate yet, but don't invest further. If nobody uses it after another year, consider removing it in the next major version.
+
+---
+
+## Output Usage
+
+8 of 27 workflows (30%) consume the Action's outputs:
+
+| Output | Consumers |
+|--------|-----------|
+| `outputs.plan` | 8 workflows |
+| `outputs.log` | 2 workflows |
+
+### How `outputs.plan` is used
+
+The dominant pattern is **roll-your-own PR comments** using `peter-evans/create-or-update-comment`:
+
+1. Run octodns-sync in a "plan" job, expose `outputs.plan` as a job output
+2. In a separate "comment" job, use `peter-evans/find-comment` to locate any existing comment
+3. Use `peter-evans/create-or-update-comment` to create or replace the comment
+4. Skip the comment if the plan contains "No changes were planned"
+
+This pattern is independently implemented by at least 3 users:
+- [bsoyka/infra](https://github.com/bsoyka/infra/blob/129e0ce7f105569edb4a2e1514b79fb30c901e10/.github/workflows/dns-dry-run.yaml) -- clean two-job approach with "no changes" filtering
+- [python-discord/infra](https://github.com/python-discord/infra/blob/80a33c2aafdfb4c5c3317a4ae20ffe130dec9a93/.github/workflows/dns-dry-run.yaml) -- similar pattern
+- [GrantBirki/dns](https://github.com/GrantBirki/dns/blob/84071641c6e77db3f2bff91bd701600581f43bfe/.github/workflows/branch-deploy.yml) -- feeds plan output into a custom deploy message updater
+
+### How `outputs.log` is used
+
+Only GrantBirki's workflows print the log output for debugging. Keep the output (it's cheap), but it's not a priority for enhancement.
+
+---
+
+## Workflow Structure
+
+### Triggers
+
+| Trigger | Count | Typical use |
+|---------|-------|-------------|
+| `push` | 14 | Deploy on merge to main |
+| `workflow_dispatch` | 13 | Manual deployment trigger |
+| `pull_request` | 9 | Dry-run / plan on PR |
+| `repository_dispatch` | 2 | External trigger |
+| `issue_comment` | 1 | IssueOps / branch deploy |
+
+`workflow_dispatch` is nearly as common as `push`, suggesting users want manual deploy capability alongside automated deploys.
+
+### Common workflow pattern: Plan + Apply
+
+Most repos have two workflows:
+1. **Plan** -- triggered on `pull_request`, runs octodns-sync without `--doit`, posts plan as PR comment
+2. **Apply** -- triggered on `push` to main (or `workflow_dispatch`), runs with `--doit`
+
+Examples: aw1cks/dns, bsoyka/infra, felixdorn/dns, diamondzxd/dns-as-code
+
+The README example only shows a single deploy workflow. A complete two-workflow example would better match real-world usage.
+
+### Runners
+
+All observed usage is on GitHub-hosted runners: `ubuntu-latest` (24 steps) and `ubuntu-20.04` (14 steps). No self-hosted runners observed.
+
+### Python versions
+
+| Version | Count |
+|---------|-------|
+| `3.10` | 13 |
+| (not specified) | 6 |
+| `3.12` | 3 |
+| `3.12.x` | 2 |
+| `3.12.1` | 1 |
+
+### DNS Providers (inferred from env vars)
+
+| Provider | Count | Env vars |
+|----------|-------|----------|
+| **Cloudflare** | 15 | `CLOUDFLARE_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` |
+| **Azure DNS** | 4 | `AZURE_APPLICATION_ID`, `AZURE_*` |
+| **PowerDNS** | 3 | `POWERDNS_API_KEY_NS1/2/3` |
+| **DigitalOcean** | 2 | `DO_TOKEN`, `DIGITALOCEAN_OAUTH_TOKEN` |
+| **OVH** | 2 | `OVH_APPLICATION_KEY`, `OVH_*` |
+
+Cloudflare dominates at ~55% of observed usage.
+
+---
+
+## Creative and Noteworthy Uses
+
+### IssueOps Branch Deploy (GrantBirki)
+
+The most sophisticated usage pattern observed. Uses `github/branch-deploy` to trigger DNS deployments via PR comments (`.deploy`, `.noop`). Dynamically sets `doit` and `force` inputs based on deploy parameters. Supports noop previews, force deploys, and deployment locking.
+
+See: [branch-deploy.yml](https://github.com/GrantBirki/dns/blob/84071641c6e77db3f2bff91bd701600581f43bfe/.github/workflows/branch-deploy.yml)
+
+### Self-Contained Action with Embedded Dependencies (starburst997)
+
+Embeds `setup-python`, `pip install`, and a pinned `requirements.txt` directly in the composite action steps -- making it a single `uses:` call with no pre-steps needed.
+
+See: [commit 3d62f02](https://github.com/starburst997/octodns-sync/commit/3d62f02338f1f1040faf71decfb3e17dca700774)
+
+### Docker-Based Action with Extended CLI Flags (antonydevanchi)
+
+Completely rewrote the Action as a Docker action using `ghcr.io`, adding `--source`, `--target`, and `--debug` flags that upstream doesn't support.
+
+See: [action.yml](https://github.com/antonydevanchi/octodns-sync/blob/main/action.yml)
+
+### Poetry Support (GrantBirki)
+
+Added a `poetry` input to run `poetry run octodns-sync` instead of bare `octodns-sync`, supporting projects that use Poetry for dependency management.
+
+See: [commit 3c85724](https://github.com/GrantBirki/octodns-action/commit/3c85724f437dd2affabab6d9b0ce86007fb837e7)
+
+---
+
+## Fork Activity Summary
+
+| Status | Count | Description |
+|--------|-------|-------------|
+| **Active + modified** | 6 | Changes ahead of upstream |
+| **Stale mirror** | 13 | Behind upstream, no unique changes |
+
+Of the 6 modified forks:
+
+| Fork | Changes | Status |
+|------|---------|--------|
+| GrantBirki/octodns-action | Poetry support, custom comments URL, zones, release tooling | Active, renamed |
+| MetaMask/octodns-sync | Python HTTP comment script (replaced curl) | Archived |
+| antonydevanchi/octodns-sync | Complete Docker rewrite with source/target/debug flags | Older, 3 stars |
+| edkadigital/octodns-sync | Dropped `comments_url` requirement | Active |
+| prezly/octodns-sync | Dropped `comments_url` requirement | Stale |
+| starburst997/octodns-sync | Self-contained action with embedded deps | Recent |
+
+---
+
+## Roadmap Signals
+
+Signals extracted from the usage data, prioritized by evidence strength.
+
+### High Priority
+
+**PR Comment Rework**
+
+30% of workflows build their own PR comment flow using `outputs.plan` + `peter-evans/create-or-update-comment`. Only 15% use the built-in `add_pr_comment`. The long-standing [#41](https://github.com/solvaholic/octodns-sync/issues/41) ("add_pr_comment adds new comment for each run") is the root cause.
+
+Evidence:
+- [bsoyka/infra](https://github.com/bsoyka/infra/blob/129e0ce7f105569edb4a2e1514b79fb30c901e10/.github/workflows/dns-dry-run.yaml) -- two-job pattern: find existing comment, create-or-update
+- [python-discord/infra](https://github.com/python-discord/infra/blob/80a33c2aafdfb4c5c3317a4ae20ffe130dec9a93/.github/workflows/dns-dry-run.yaml) -- same pattern with "No changes" filtering
+- MetaMask fork rewrote comment posting entirely (Python HTTP script)
+- edkadigital and prezly both dropped the `comments_url` requirement
+
+Options:
+1. Switch `comment.sh` to use `gh pr comment` with find-and-replace semantics (update existing comment)
+2. Deprecate the built-in comment feature and document the `peter-evans` pattern as the recommended approach
+3. Both: improve the built-in feature AND document the DIY pattern for advanced use cases
+
+Also consider: skip commenting when the plan shows no changes (the bsoyka/python-discord pattern).
+
+**"No changes" detection**
+
+Multiple users independently implemented `if: ${{ ! contains(outputs.plan, 'No changes were planned') }}` to skip PR comments when nothing changed. This should be a first-class output: `outputs.has_changes` (boolean).
+
+### Medium Priority
+
+**Missing CLI flags**
+
+antonydevanchi's fork added `source`, `target`, and `debug` inputs mapping to real `octodns-sync` CLI flags. These are straightforward to add (just pass-through to the CLI) and would reduce the need to fork.
+
+**Poetry / alternative package manager support**
+
+GrantBirki added a `poetry` input. A more generic approach: a `command_prefix` input (default: empty) that prepends to the octodns-sync invocation. This would support poetry (`poetry run`), pipx, or any other wrapper without adding tool-specific inputs.
+
+### Low Priority
+
+**`outputs.log` adoption**: Only 2 workflows reference it. Keep the output, don't invest in enhancing it.
+
+**`zones` input adoption**: Zero public users. Wait and see.
+
+---
+
+## Fork Changes Worth Considering
+
+| Fork | Change | Recommendation |
+|------|--------|----------------|
+| GrantBirki | [Poetry support](https://github.com/GrantBirki/octodns-action/commit/3c85724f437dd2affabab6d9b0ce86007fb837e7) | Consider generic `command_prefix` input |
+| GrantBirki | Uses `${{ github.action_path }}` instead of `${GITHUB_ACTION_PATH}` | Already addressed in [#107](https://github.com/solvaholic/octodns-sync/pull/107) |
+| antonydevanchi | [source/target/debug CLI flags](https://github.com/antonydevanchi/octodns-sync/blob/main/action.yml) | Add as optional inputs |
+| starburst997 | [Self-contained action with embedded deps](https://github.com/starburst997/octodns-sync/commit/3d62f02338f1f1040faf71decfb3e17dca700774) | Interesting but too opinionated for upstream -- document as alternative |
+| edkadigital + prezly | Dropped `comments_url` requirement | Already addressed in PR comment rework |
+
+---
+
+## Documentation Improvements
+
+1. **Document the Plan + Apply pattern**: The dominant two-workflow pattern should be in the README
+2. **Document the DIY PR comment pattern**: The `peter-evans/create-or-update-comment` approach is the community standard
+3. **Add `workflow_dispatch`**: Nearly half of observed workflows include it
+4. **Update runner/Python version recommendations**: Some users still reference `ubuntu-20.04` (EOL) and Python 3.10
+
+### DIY PR comment example
+
+```yaml
+# In the plan job
+outputs:
+  plan: ${{ steps.octodns.outputs.plan }}
+
+# In a separate comment job
+- uses: peter-evans/find-comment@v3
+  id: fc
+  with:
+    issue-number: ${{ github.event.pull_request.number }}
+    comment-author: github-actions[bot]
+    body-includes: "OctoDNS Plan"
+- uses: peter-evans/create-or-update-comment@v4
+  with:
+    comment-id: ${{ steps.fc.outputs.comment-id }}
+    issue-number: ${{ github.event.pull_request.number }}
+    body: |
+      ## OctoDNS Plan
+      ${{ needs.plan.outputs.plan }}
+    edit-mode: replace
+```
+
+---
+
+## Open Questions from Community
+
+| Issue | Status | Signal |
+|-------|--------|--------|
+| [#72](https://github.com/solvaholic/octodns-sync/issues/72) | Open | How to safely run on `pull_request_target`? Security question about fork PRs accessing secrets |
+| [#95](https://github.com/solvaholic/octodns-sync/issues/95) | Open | Teach this Action to test itself |
+| [#101](https://github.com/solvaholic/octodns-sync/issues/101) | Closed | Custom working-directory support; may still be relevant for monorepo users |
+| [#108](https://github.com/solvaholic/octodns-sync/issues/108) | Open | Update major tag workflow fails; blocks version tag updates, contributes to `@main` pinning |
+| [octodns/octodns#673](https://github.com/octodns/octodns/issues/673) | Closed | Mention octodns-sync in octodns README |


### PR DESCRIPTION
Adds two research docs based on analysis of public GitHub data (forks, workflows, community signals, octodns docs, and reference implementations).

### What's here

- **[docs/research/usage-and-roadmap.md](docs/research/usage-and-roadmap.md)** -- How people actually use octodns-sync: version pinning, input/output usage, workflow patterns, creative uses, fork changes, and roadmap signals prioritized by evidence.

- **[docs/research/octodns-design.md](docs/research/octodns-design.md)** -- How octodns is designed to be used, all 7 CLI tools, reference implementations (hackclub/dns, kubernetes/k8s.io), gap analysis, and which workflows are worth automating.

### Data sources

- 19 forks (6 with meaningful changes)
- 27 public workflow files from 15 repos
- octodns docs, CLI source, and reference implementations
- Open issues and community discussion

### What's NOT here

Raw data files (API responses, workflow YAMLs, fork comparisons) were collected locally but excluded from this branch to keep the PR clean. The research docs summarize and cite everything with permalinks.